### PR TITLE
feature: expose last upstream send state to balancer FFI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,9 @@ name: Build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 jobs:
   test:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -119,6 +119,10 @@ jobs:
           # Sibling repos — build scripts reference them via $root/../<name>
           git clone --depth=1 https://github.com/openresty/openresty.git             ../openresty
           git clone --depth=1 https://github.com/openresty/no-pool-nginx.git         ../no-pool-nginx
+          # The upstream patch still carries 1.31.1's numeric nginx_version.
+          perl -0pi -e \
+            's/#define nginx_version      1031001/#define nginx_version      1031002/' \
+            ../no-pool-nginx/nginx-1.31.2-no_pool.patch
           git clone --depth=1 https://github.com/openresty/lua-upstream-nginx-module.git ../lua-upstream-nginx-module
           git clone --depth=1 https://github.com/openresty/echo-nginx-module.git         ../echo-nginx-module
           git clone --depth=1 https://github.com/openresty/nginx-eval-module.git         ../nginx-eval-module

--- a/src/ngx_http_lua_balancer.c
+++ b/src/ngx_http_lua_balancer.c
@@ -59,13 +59,21 @@ struct ngx_http_lua_balancer_peer_data_s {
     ngx_str_t                          *addr_text;
 
     int                                 last_peer_state;
+    off_t                               last_bytes_sent;
 
 #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
     unsigned                            cloned_upstream_conf:1;
 #endif
 
+    unsigned                            last_request_sent:1;
+    unsigned                            last_request_body_sent:1;
     unsigned                            keepalive:1;
 };
+
+
+#define NGX_HTTP_LUA_BALANCER_SEND_NONE      0
+#define NGX_HTTP_LUA_BALANCER_SEND_PARTIAL   1
+#define NGX_HTTP_LUA_BALANCER_SEND_COMPLETE  2
 
 
 #if (NGX_HTTP_SSL)
@@ -594,6 +602,15 @@ ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
 
     if (bp->sockaddr && bp->socklen) {
         bp->last_peer_state = (int) state;
+        bp->last_request_sent = u->request_sent;
+        bp->last_request_body_sent = u->request_body_sent;
+
+        if (u->state) {
+            bp->last_bytes_sent = u->state->bytes_sent;
+
+        } else {
+            bp->last_bytes_sent = c ? c->sent : 0;
+        }
 
         if (pc->tries) {
             pc->tries--;
@@ -1250,6 +1267,52 @@ ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
     }
 
     return bp->last_peer_state;
+}
+
+
+int
+ngx_http_lua_ffi_balancer_get_last_send_state(ngx_http_request_t *r,
+    off_t *bytes, char **err)
+{
+    ngx_http_lua_ctx_t                 *ctx;
+    ngx_http_upstream_t                *u;
+    ngx_http_lua_balancer_peer_data_t  *bp;
+
+    if (r == NULL) {
+        *err = "no request found";
+        return NGX_ERROR;
+    }
+
+    u = r->upstream;
+
+    if (u == NULL) {
+        *err = "no upstream found";
+        return NGX_ERROR;
+    }
+
+    ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
+    if (ctx == NULL) {
+        *err = "no ctx found";
+        return NGX_ERROR;
+    }
+
+    if ((ctx->context & NGX_HTTP_LUA_CONTEXT_BALANCER) == 0) {
+        *err = "API disabled in the current context";
+        return NGX_ERROR;
+    }
+
+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
+    *bytes = bp->last_bytes_sent;
+
+    if (bp->last_request_body_sent) {
+        return NGX_HTTP_LUA_BALANCER_SEND_COMPLETE;
+    }
+
+    if (bp->last_bytes_sent > 0) {
+        return NGX_HTTP_LUA_BALANCER_SEND_PARTIAL;
+    }
+
+    return NGX_HTTP_LUA_BALANCER_SEND_NONE;
 }
 
 

--- a/t/194-balancer-last-send-state.t
+++ b/t/194-balancer-last-send-state.t
@@ -4,7 +4,7 @@ use Test::Nginx::Socket::Lua;
 
 repeat_each(2);
 
-plan tests => repeat_each() * (blocks() * 4);
+plan tests => repeat_each() * (blocks() * 5);
 
 no_long_string();
 run_tests();

--- a/t/194-balancer-last-send-state.t
+++ b/t/194-balancer-last-send-state.t
@@ -1,0 +1,215 @@
+# vim:set ft= ts=4 sw=4 et fdm=marker:
+
+use Test::Nginx::Socket::Lua;
+
+repeat_each(2);
+
+plan tests => repeat_each() * (blocks() * 4);
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: first balancer run has no last send state
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+
+    upstream backend {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local ffi = require "ffi"
+            local C = ffi.C
+
+ffi.cdef[[
+int ngx_http_lua_ffi_balancer_get_last_send_state(ngx_http_request_t *r,
+    long *bytes, char **err);
+]]
+
+            local base = require "resty.core.base"
+            local r = base.get_request()
+            local bytes = ffi.new("long[1]")
+            local errmsg = ffi.new("char *[1]")
+            local rc = C.ngx_http_lua_ffi_balancer_get_last_send_state(r,
+                                                                       bytes,
+                                                                       errmsg)
+
+            if rc < 0 then
+                ngx.log(ngx.ERR, "get last send state failed: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local states = {
+                [0] = "none",
+                [1] = "partial",
+                [2] = "complete",
+            }
+
+            ngx.log(ngx.ERR, "last send state: ", states[rc],
+                    ", bytes: ", tonumber(bytes[0]))
+
+            local balancer = require "ngx.balancer"
+            assert(balancer.set_current_peer("127.0.0.1", 81))
+        }
+    }
+--- config
+    location = /t {
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- error_log
+last send state: none, bytes: 0
+--- no_error_log
+get last send state failed
+[alert]
+
+
+
+=== TEST 2: connection failure before sending bytes reports none
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+
+    upstream backend {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local ffi = require "ffi"
+            local C = ffi.C
+
+ffi.cdef[[
+int ngx_http_lua_ffi_balancer_get_last_send_state(ngx_http_request_t *r,
+    long *bytes, char **err);
+]]
+
+            local base = require "resty.core.base"
+            local r = base.get_request()
+            local bytes = ffi.new("long[1]")
+            local errmsg = ffi.new("char *[1]")
+            local rc = C.ngx_http_lua_ffi_balancer_get_last_send_state(r,
+                                                                       bytes,
+                                                                       errmsg)
+
+            if rc < 0 then
+                ngx.log(ngx.ERR, "get last send state failed: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local states = {
+                [0] = "none",
+                [1] = "partial",
+                [2] = "complete",
+            }
+
+            ngx.ctx.tries = (ngx.ctx.tries or 0) + 1
+            ngx.log(ngx.ERR, "try: ", ngx.ctx.tries,
+                    ", last send state: ", states[rc],
+                    ", bytes: ", tonumber(bytes[0]))
+
+            local balancer = require "ngx.balancer"
+            if ngx.ctx.tries == 1 then
+                assert(balancer.set_more_tries(1))
+            end
+
+            assert(balancer.set_current_peer("127.0.0.1", 81))
+        }
+    }
+--- config
+    location = /t {
+        proxy_next_upstream error timeout;
+        proxy_pass http://backend;
+    }
+--- request
+    GET /t
+--- response_body_like: 502 Bad Gateway
+--- error_code: 502
+--- grep_error_log eval: qr/try: \d, last send state: \w+, bytes: \d+/
+--- grep_error_log_out
+try: 1, last send state: none, bytes: 0
+try: 2, last send state: none, bytes: 0
+--- no_error_log
+get last send state failed
+[alert]
+
+
+
+=== TEST 3: completed request body reports complete on retry
+--- http_config
+    lua_package_path "../lua-resty-core/lib/?.lua;;";
+
+    server {
+        listen 127.0.0.1:$TEST_NGINX_RAND_PORT_1;
+
+        location / {
+            return 503;
+        }
+    }
+
+    upstream backend {
+        server 0.0.0.1;
+
+        balancer_by_lua_block {
+            local ffi = require "ffi"
+            local C = ffi.C
+
+ffi.cdef[[
+int ngx_http_lua_ffi_balancer_get_last_send_state(ngx_http_request_t *r,
+    long *bytes, char **err);
+]]
+
+            local base = require "resty.core.base"
+            local r = base.get_request()
+            local bytes = ffi.new("long[1]")
+            local errmsg = ffi.new("char *[1]")
+            local rc = C.ngx_http_lua_ffi_balancer_get_last_send_state(r,
+                                                                       bytes,
+                                                                       errmsg)
+
+            if rc < 0 then
+                ngx.log(ngx.ERR, "get last send state failed: ",
+                        ffi.string(errmsg[0]))
+                return
+            end
+
+            local states = {
+                [0] = "none",
+                [1] = "partial",
+                [2] = "complete",
+            }
+
+            ngx.ctx.tries = (ngx.ctx.tries or 0) + 1
+            ngx.log(ngx.ERR, "try: ", ngx.ctx.tries,
+                    ", last send state: ", states[rc],
+                    ", bytes: ", tonumber(bytes[0]))
+
+            local balancer = require "ngx.balancer"
+            if ngx.ctx.tries == 1 then
+                assert(balancer.set_more_tries(1))
+            end
+
+            assert(balancer.set_current_peer("127.0.0.1",
+                                             $TEST_NGINX_RAND_PORT_1))
+        }
+    }
+--- config
+    location = /t {
+        proxy_next_upstream http_503 non_idempotent;
+        proxy_pass http://backend;
+    }
+--- request
+    POST /t
+    hello world
+--- response_body_like: 503 Service Temporarily Unavailable
+--- error_code: 503
+--- grep_error_log eval: qr/try: \d, last send state: \w+, bytes: \d+/
+--- grep_error_log_out eval
+qr/^try: 1, last send state: none, bytes: 0
+try: 2, last send state: complete, bytes: [1-9]\d*$/
+--- no_error_log
+get last send state failed
+[alert]


### PR DESCRIPTION
## Summary

- add a balancer peer snapshot for the previous upstream send state
- expose `ngx_http_lua_ffi_balancer_get_last_send_state()` for lua-resty-core
- add focused FFI coverage for first-attempt, zero-byte retry, and completed-body retry states

## Notes

- Refs #3
- Local Test::Nginx execution was skipped as requested; CI is the source of truth for runtime verification.
- The user-facing `ngx.balancer.get_last_send_state()` wrapper will be implemented in the paired `membphis/lua-resty-core` PR.

## Verification

- `git diff --check`
- `PERL5LIB=/tmp/codex-perl5/lib/perl5 perl -I/tmp/codex-test-nginx/lib -c t/194-balancer-last-send-state.t`
